### PR TITLE
Reduce crate size by excluding screenshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/MustafaSalih1993/tai"
 description = "tai (Terminal Ascii Image) tool to convert images to ascii"
+include = ["src/**/*", "README.md"]
 
 
 [dependencies]


### PR DESCRIPTION
Here is the output of `cargo diet`:

```
┌───────────────────┬─────────────┐
│ Removed File      │ Size (Byte) │
├───────────────────┼─────────────┤
│ .gitignore        │           8 │
│ screenshots/1.gif │     9454256 │
└───────────────────┴─────────────┘
Saved 100% or 9.5 MB in 2 files (of 9.5 MB and 10 files in entire crate)
```